### PR TITLE
Update try-extensions-locally guide

### DIFF
--- a/docs/tembo-cloud/try-extensions-locally.md
+++ b/docs/tembo-cloud/try-extensions-locally.md
@@ -35,7 +35,7 @@ trunk install pgmq
 ```
 psql postgres://postgres:postgres@localhost:5432
 ```
-- Enable an extension
+- Enable an extension. Note a hyphenated extension name, e.g., uuid-ossp, will require double quotes when enabling.
 ```
 CREATE EXTENSION pgmq CASCADE;
 ```


### PR DESCRIPTION
Add small note to illustrate cases where CREATE / DROP EXTENSION would require double quotes:

```
postgres=# \dx
     List of installed extensions
 Name | Version | Schema | Description
------+---------+--------+-------------
(0 rows)

postgres=# CREATE EXTENSION uuid-ossp;
ERROR:  syntax error at or near "-"
LINE 1: CREATE EXTENSION uuid-ossp;
                             ^
postgres=# CREATE EXTENSION "uuid-ossp";
CREATE EXTENSION
postgres=# \dx
                          List of installed extensions
   Name    | Version | Schema |                   Description
-----------+---------+--------+-------------------------------------------------
 uuid-ossp | 1.1     | public | generate universally unique identifiers (UUIDs)
(1 row)

postgres=# DROP EXTENSION uuid-ossp;
ERROR:  syntax error at or near "-"
LINE 1: DROP EXTENSION uuid-ossp;
                           ^
postgres=# DROP EXTENSION "uuid-ossp";
DROP EXTENSION
postgres=# \dx
     List of installed extensions
 Name | Version | Schema | Description
------+---------+--------+-------------
(0 rows)

postgres=#
```