### PR TITLE
Fix thumbnails in blog posts

### DIFF
--- a/blog/2023-09-28-pgmq-internals/index.md
+++ b/blog/2023-09-28-pgmq-internals/index.md
@@ -3,7 +3,7 @@ slug: postgres-extension-in-rust-pgmq
 title: "Anatomy of a Postgres extension written in Rust: pgmq"
 authors: [rjzv]
 tags: [postgres, pgmq, rust, pgrx, extensions]
-image: pgmq-archive.png
+image: ./pgmq-archive.png
 ---
 
 In my [previous submission](https://tembo.io/blog/pgmq-with-python) to this space, I described my experience with [pgmq](https://github.com/tembo-io/pgmq) while using the Python library. In this post, I'll share what I found after inspecting the code.

--- a/blog/2023-10-03-clerk-fdw/index.md
+++ b/blog/2023-10-03-clerk-fdw/index.md
@@ -3,7 +3,7 @@ slug: clerk-fdw
 title: "Unlocking value from your Clerk User Management platform with Postgres"
 authors: [jay]
 tags: [postgres, extensions]
-image: clerk-flowchart.png
+image: ./clerk-flowchart.png
 ---
 
 # Unlocking value from your Clerk User Management platform with Postgres


### PR DESCRIPTION
It looks like by default, the post thumbnails are searched in the root directory, e.g.:

"property="og:image" content="https://tembo.io/pgmq-archive.png""

The result is something like: 
https://x.com/planetpostgres/status/1707542061157699732?s=20

I saw that other posts use "./<filename>.png" and the thumbnails of those look good, e.g.:
https://x.com/planetpostgres/status/1707768565917433991?s=20

In this PR I am updating two posts to correct the problem.