### PR TITLE
Update local-tembo-operator.md

### DIFF
--- a/docs/tembo-stacks/local-tembo-operator.md
+++ b/docs/tembo-stacks/local-tembo-operator.md
@@ -60,7 +60,7 @@ export PGPASSWORD=$(kubectl get secrets/sample-machine-learning-connection --tem
 
 ## Step 7: Expose the service to localhost 
 
-kubectl port-forward pod/sample-machine-learning-1 5432:5432 
+kubectl port-forward svc/sample-machine-learning-rw 5432:5432 
 
 ## Step 8: Connect
 

--- a/docs/tembo-stacks/local-tembo-operator.md
+++ b/docs/tembo-stacks/local-tembo-operator.md
@@ -12,6 +12,7 @@ This tutorial requires the following prerequisites:
 - [Docker](https://www.docker.com/) running locally
 - [just](https://github.com/casey/just) command runner installed
 - [helm](https://helm.sh/) package manager installed
+- (Rust](https://www.rust-lang.org/tools/install) installed
 
 ## Step 1: Clone the repo 
 
@@ -55,22 +56,18 @@ Get your connection password and save it as an environment variable.
 
 ```bash
 export PGPASSWORD=$(kubectl get secrets/sample-machine-learning-connection --template={{.data.password}} | base64 -D)
-```  
-
-## Step 7: Configure /etc/hosts
-
-Add the following line to `/etc/hosts`
-
-```bash
-127.0.0.1 sample-machine-learning.localhost
 ```
+
+## Step 7: Expose the service to localhost 
+
+kubectl port-forward pod/sample-machine-learning-1 5432:5432 
 
 ## Step 8: Connect
 
 Connect to the running Postgres instance:
 
 ```bash
-psql postgres://postgres:$PGPASSWORD@sample-machine-learning.localhost:5432
+psql postgres://postgres:$PGPASSWORD@localhost:5432
 ```  
 
 ## Step 9. Enjoy and ask questions!


### PR DESCRIPTION
Hello Tembo team, I tried running the instructions in  this local-tembo-operator on both Osx and Windows and ran into some issues. 
1. Error on cargo commands 
2. The instructions to connect on localhost (even after adding etc/hosts entry do not work since the service is not exposed). 

Not sure what the thinking here was: 

So I made the following changes to this file: 
Add rust as prerequisite;
Add port-forward to expose service from the cluster.