### PR TITLE
Twitter to X

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -167,8 +167,8 @@ const config = {
             href: '/docs',
           },
           {
-            label: 'Twitter',
-            href: 'https://twitter.com/tembo_io',
+            label: 'X',
+            href: 'https://x.com/tembo_io',
           },
           {
             label: 'LinkedIn',


### PR DESCRIPTION
Hello there,

I've updated the social media references in this repository to reflect the recent name change of Twitter to "X," in order to ensure accuracy and consistency. This change aligns the content with the current naming conventions. Please review and merge at your convenience.

Thank you!