### PR TITLE
Fix Postgres Basics category description.

### DIFF
--- a/docs/postgres_guides/postgres-basics/_category_.json
+++ b/docs/postgres_guides/postgres-basics/_category_.json
@@ -4,6 +4,6 @@
   "collapsible": true,
   "link": {
     "type": "generated-index",
-    "description": "Stacks are pre-built, use case-specific configurations and pre-built packages of Postgres, enabling you to quickly deploy specialized data services that can replace external, non-Postgres data services."
+    "description": "Postgres, as a relational database management system, uses SQL (Structured Query Language) to define and manipulate data. In these guides, you will learn the absolute minimum to start using Postgres."
   }
 }


### PR DESCRIPTION
The description of the "Postgres Basics" category was a bit off. This PR improves it.