### PR TITLE
Landing hero scaling

### DIFF
--- a/landing/src/components/Extension.astro
+++ b/landing/src/components/Extension.astro
@@ -17,7 +17,7 @@ const { extensionTitle, titleStyles, wrapperStyles, href } = Astro.props;
 >
 	<div
 		class={cx(
-			'flex flex-col items-center justify-between rounded-[12px] customXs:rounded-[20px] w-[138px] h-[123px] customXs:w-[230px] customXs:h-[205px] p-[8.4px] customXs:p-3.5',
+			'flex flex-col items-center justify-between rounded-[12px] customXs:rounded-[20px] w-[138px] h-full customXs:w-[230px] customXs:h-[205px] p-[8.4px] customXs:p-3.5',
 			!wrapperStyles ? 'bg-neon' : '',
 			wrapperStyles,
 		)}

--- a/landing/src/components/HeroCard.astro
+++ b/landing/src/components/HeroCard.astro
@@ -43,7 +43,7 @@ const {
 		</svg>
 		<p
 			class={cx(
-				'text-start text-[7.8px] customXs:text-[13px] font-medium',
+				'text-start text-[13px] font-medium',
 				!descriptionStyles ? 'text-blue' : '',
 				descriptionStyles,
 			)}
@@ -55,12 +55,7 @@ const {
 		<slot />
 		{
 			title && (
-				<h2
-					class={cx(
-						'text-[17.16px] customXs:text-[18px] font-bold text-black',
-						titleStyles,
-					)}
-				>
+				<h2 class={cx('text-[18px] font-bold text-black', titleStyles)}>
 					{title}
 				</h2>
 			)
@@ -69,7 +64,7 @@ const {
 			subTitle && (
 				<p
 					class={cx(
-						'text-[11px] customXs:text-sm font-semibold text-black mb-[25px]',
+						'text-sm font-semibold text-black mb-[25px]',
 						subTitleStyles,
 					)}
 				>

--- a/landing/src/pages/index.astro
+++ b/landing/src/pages/index.astro
@@ -50,7 +50,7 @@ const currentPath = Astro.url.pathname;
 				class='tembo-hero-section mt-[25px] customXs:mt-[40px] md:mt-[80px]'
 			>
 				<div
-					class='flex flex-col items-center justify-center z-10 pb-[100px] relative'
+					class='flex flex-col items-center justify-center z-10 pb-[50px] customXs:pb-[100px] relative'
 				>
 					<header class='text-center slide-enter-content'>
 						<h2
@@ -75,7 +75,9 @@ const currentPath = Astro.url.pathname;
 			<section
 				class='tembo-card-stack-section flex items-center justify-center z-10'
 			>
-				<div class='flex items-start gap-4 z-10'>
+				<div
+					class='flex items-start gap-4 z-10 scale-75 customXs:scale-100'
+				>
 					<div
 						class='flex flex-col justify-center items-center gap-4 mt-[65px]'
 					>
@@ -198,10 +200,12 @@ const currentPath = Astro.url.pathname;
 				</div>
 			</section>
 		</Container>
-		<section class='tembo-build-any-application-section pt-14 pb-[150px]'>
+		<section
+			class='tembo-build-any-application-section pt-4 customXs:pt-14 pb-[150px]'
+		>
 			<Container>
 				<div
-					class='flex flex-col items-center justify-center mt-36 gap-6'
+					class='flex flex-col items-center justify-center mt-9 customXs:mt-36 gap-6'
 				>
 					<h3 class='text-neon font-secondary'>BUILT TO SCALE</h3>
 					<h1

--- a/landing/src/pages/index.astro
+++ b/landing/src/pages/index.astro
@@ -90,7 +90,7 @@ const currentPath = Astro.url.pathname;
 							<Image
 								src={AutoApi}
 								alt='Auto Api'
-								class='h-[150px] w-full rounded-xl'
+								class='w-full rounded-xl'
 							/>
 						</HeroCard>
 						<HeroCard
@@ -118,7 +118,7 @@ const currentPath = Astro.url.pathname;
 							<Image
 								src={LocalSearch}
 								alt='Vector Store'
-								class='h-[150px] w-full rounded-xl'
+								class='w-full rounded-xl'
 							/>
 						</HeroCard>
 					</div>
@@ -138,7 +138,7 @@ const currentPath = Astro.url.pathname;
 							<Image
 								src={DataWarehouse}
 								alt='Vector Store'
-								class='h-[150px] w-full rounded-xl'
+								class='w-full rounded-xl'
 							/>
 						</HeroCard>
 						<HeroCard
@@ -168,7 +168,7 @@ const currentPath = Astro.url.pathname;
 							<Image
 								src={VectorStore}
 								alt='Vector Store'
-								class='h-[150px] w-full rounded-xl'
+								class='w-full rounded-xl'
 							/>
 						</HeroCard>
 					</div>
@@ -186,7 +186,7 @@ const currentPath = Astro.url.pathname;
 							<Image
 								src={Realtime}
 								alt='Vector Store'
-								class='h-[150px] w-full rounded-xl'
+								class='w-full rounded-xl'
 							/>
 						</HeroCard>
 						<HeroCard


### PR DESCRIPTION
- Scale HeroCard font on mobile
- Scale down hero section to 75% and reduce margin + padding
- Update extension card images on mobile to just use `w-full`