### PR TITLE
Update intro to include geospatial link.

### DIFF
--- a/docusaurus/docs/tembo-stacks/intro-to-stacks.md
+++ b/docusaurus/docs/tembo-stacks/intro-to-stacks.md
@@ -22,7 +22,7 @@ A tembo stack is a pre-built, use case specific Postgres deployment which enable
 |[Message Queue](message-queue.md)| Amazon SQS, RabbitMQ, Redis |
 |[Data Warehouse](datawarehouse.md)| Snowflake, Bigquery |
 |Mongo Alternative on Postgres| MongoDB | 
-|Geospatial| ESRI, Oracle | 
+|[Geospatial](geospatial.md)| ESRI, Oracle | 
 |[Vector DB](vector-db.md)| Pinecone, Weaviate |
 |[Standard](standard.md)| Amazon RDS |
 


### PR DESCRIPTION
This PR adds a link to the Geospatial Stack documentation within the table on the Introduction to Stacks page.