### PR TITLE
Update MongoAlt Stack docs best practices.

### DIFF
--- a/docusaurus/docs/tembo-stacks/mongo-alternative.md
+++ b/docusaurus/docs/tembo-stacks/mongo-alternative.md
@@ -4,18 +4,24 @@ sidebar_position: 10
 
 # Tembo MongoAlternative
 
-The Tembo MongoAlternative Stack is designed to offer Mongo protocol compatibility with Postgres. 
-Leveraging the power of FerretDB, Tembo users can both migrate from MongoDB to Postgres, as well as interact with their data in a remarkably familiar to them.
+The Tembo MongoAlternative Stack is designed to offer MongoDB (Mongo) protocol compatibility with PostgreSQL (Postgres). 
+Leveraging the power of FerretDB, Tembo users can both migrate from Mongo to Postgres, as well as interact with their data in a remarkably familiar to them.
 In other words, users have Mongo-compatible storage without needing to change their application.
 
 ## Apps & Extensions
 
-- [FerretDB](https://docs.ferretdb.io/) - `FerretDB` is an open-source proxy build on Postgres that translates MongoDB wire protocol queries to SQL.
+- [FerretDB](https://docs.ferretdb.io/) - `FerretDB` is an open-source proxy build on Postgres that translates Mongo wire protocol queries to SQL.
 - Extensions from [Trunk](https://pgt.dev/) can be installed on-demand.
 
 ## Getting started
 
-### Download mongosh (MongoDB Shell)
+Before jumping in, it's important to note some recommended usage practices:
+- psql (PostgreSQL Client): When accessing the database via psql, we advise read-only operations.
+This is to maintain the integrity of the data structure and compatibility with FerretDB.
+- mongosh (MongoDB Shell): For read-write operations, including inserting, updating, and deleting data, please use mongosh.
+This ensures that all changes are properly managed and reflected in both Mongo and Postgres representations.
+
+### Download mongosh
 
 Similar to `psql`, `mongosh` is a client used to query and interact with the data in your Mongo database and is compatible with FerretDB.
 
@@ -76,7 +82,20 @@ When you conduct these operations, you should see the following automated respon
 }
 ```
 
-### Sample queries
+From there you can interact with the data using the following [FerretDB supported commands](https://docs.ferretdb.io/reference/supported-commands/).
+
+### Reading from psql
+
+Similar to other stacks you can copy the connection string from your UI or fill in and run the following psql command:
+```bash
+psql 'postgresql://postgres:<your-password>@<your-host>:5432/postgres'
+```
+
+Once connected to the instance, running `dn` will list the schemas and show `ferretdb` and an option.
+Running ```SET search_path TO ferretdb;``` will allow you to interact with your data stored via FerretDB.
+At this point it's important to reemphasize that our current recommendation to treat `psql` as read only when using the MongoAlternative Stack.
+
+### Sample mongosh queries
 
 #### Query 1
 List the collections (table equivalent to relational databases).

--- a/docusaurus/docs/tembo-stacks/mongo-alternative.md
+++ b/docusaurus/docs/tembo-stacks/mongo-alternative.md
@@ -86,12 +86,12 @@ From there you can interact with the data using the following [FerretDB supporte
 
 ### Reading from psql
 
-Similar to other stacks you can copy the connection string from your UI or fill in and run the following psql command:
+Similar to other stacks you can copy the connection string from the Tembo UI or fill in and run the following psql command:
 ```bash
 psql 'postgresql://postgres:<your-password>@<your-host>:5432/postgres'
 ```
 
-Once connected to the instance, running `dn` will list the schemas and show `ferretdb` and an option.
+Once connected to the instance, running `\dn` will list the schemas and show `ferretdb` and an option.
 Running ```SET search_path TO ferretdb;``` will allow you to interact with your data stored via FerretDB.
 At this point it's important to reemphasize that our current recommendation to treat `psql` as read only when using the MongoAlternative Stack.
 


### PR DESCRIPTION
Our current recommended best practices is to treat `psql` connections as read only and the `mongosh` connections as both read and write. This PR updates our docs to reflect that.