### PR TITLE
Drop Traefik prerequisite from operator installation guide

### DIFF
--- a/docusaurus/docs/tembo-stacks/tembo-operator-install.md
+++ b/docusaurus/docs/tembo-stacks/tembo-operator-install.md
@@ -13,7 +13,6 @@ Tembo provides Helm charts as a first-class method of installation on Kubernetes
 - [Install Helm version 3 or later](https://helm.sh/docs/intro/install/).
 - Install a supported version of Kubernetes (currently only 1.25 is supported, but newer versions should work).
 - Install cert-manager [with Helm](https://cert-manager.io/docs/installation/helm/#4-install-cert-manager)
-- Install traefik ingress controller [with Helm](https://doc.traefik.io/traefik/getting-started/install-traefik/#use-the-helm-chart)
 - **extra**: For monitoring, you can install the prometheus-operator using the 
 [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack)
 Helm chart.


### PR DESCRIPTION
Traefik CRDs are no longer a dependency for the tembo operator (https://github.com/tembo-io/tembo/pull/528). Dropping prerequisite from installation documentation.