### PR TITLE
Fix description typo

### DIFF
--- a/landing/src/content/blog/2024-02-12-extension-ecosystem-jobs/index.md
+++ b/landing/src/content/blog/2024-02-12-extension-ecosystem-jobs/index.md
@@ -6,7 +6,7 @@ tags: [postgres, extensions, ecosystem, packaging, distribution, architecture, j
 image: ./extension-ecosystem.png
 date: 2024-02-21T17:00
 description: |
-  These challenges of the current Postgres extension ecosystem and the
+  The challenges of the current Postgres extension ecosystem and the
   interest and energy put into exploring new solutions make clear that the
   time has come to revisit the whole idea. We begin with a survey of the
   jobs to be done by extensions packaging and distribution.


### PR DESCRIPTION
I assume we don't want to fix the slug, as it would change the URL and could create duplicates downstream. :-(