### PR TITLE
Fix quotes in samples

### DIFF
--- a/docusaurus/docs/postgres_guides/connecting-to-postgres-with-nodejs/connecting-to-postgres-with-nodejs.md
+++ b/docusaurus/docs/postgres_guides/connecting-to-postgres-with-nodejs/connecting-to-postgres-with-nodejs.md
@@ -32,10 +32,10 @@ Make sure you initialize the pg package at the top of program
 
 ``` js
 const client = new Client({
-  user: ‘username',
+  user: 'username',
   password: 'password',
   host: 'host',
-  port: ‘port_number’,
+  port: 'port_number',
   database: 'database_name',
 });
 ```
@@ -85,10 +85,10 @@ const { Client } = require('pg');
 
 // Database connection configuration
 const dbConfig = {
-  user: ‘username',
+  user: 'username',
   password: 'password',
   host: 'host',
-  port: ‘port_number’,
+  port: 'port_number',
   database: 'database_name',
 };
 


### PR DESCRIPTION
A user pointed out some bad quotes in one of our guides. This fixes them.