### PR TITLE
Update stacks docs

### DIFF
--- a/docusaurus/docs/tembo-stacks/datawarehouse.md
+++ b/docusaurus/docs/tembo-stacks/datawarehouse.md
@@ -6,6 +6,11 @@ sidebar_position: 3
 
 Tembo's DataWarehouse is tuned and configured for data warehouse workloads. Extract, Transform and Load data from external sources using extensions. Build centralize datastore for analytical and tactical queries.
 
+## Container Image
+
+This stack is built with a custom image, `dw-cnpg`.
+Detailed information about this image, as well as other stack images can be found in the official [tembo-images repository](https://github.com/tembo-io/tembo-images).
+
 ## Extensions
 
 - `pg_stat_statements` provides statistics on SQL statements executed by the database. It helps users analyze query performance and identify areas for optimization.

--- a/docusaurus/docs/tembo-stacks/datawarehouse.md
+++ b/docusaurus/docs/tembo-stacks/datawarehouse.md
@@ -8,8 +8,9 @@ Tembo's DataWarehouse is tuned and configured for data warehouse workloads. Extr
 
 ## Container Image
 
-This stack is built with a custom image, `dw-cnpg`.
-Detailed information about this image, as well as other stack images can be found in the official [tembo-images repository](https://github.com/tembo-io/tembo-images).
+This stack is built with a custom image, `dw-cnpg`, which you can find more detailed information about within the [dw-cnpg Dockerfile](https://github.com/tembo-io/tembo-images/blob/main/dw-cnpg/Dockerfile)
+
+For interest in the other Stack-specific images, please visit the official [tembo-images repository](https://github.com/tembo-io/tembo-images).
 
 ## Extensions
 

--- a/docusaurus/docs/tembo-stacks/geospatial.md
+++ b/docusaurus/docs/tembo-stacks/geospatial.md
@@ -10,13 +10,14 @@ Whether dealing with spatial objects, location queries, or GIS (geographic infor
 ## Extensions
 
 - [pg_stat_statements](https://www.postgresql.org/docs/current/pgstatstatements.html) - `pg_stat_statements` is an additional supplied module that provides valuable metrics related to query performance.
+- [fuzzystrmatch](https://www.postgresql.org/docs/current/fuzzystrmatch.html) - `fuzzystrmatch` is an additional supplied module that helps with string matching, including approximate or "fuzzy" matches. Useful in tasks like deduplication or linking different data sets where string data may not be exactly the same.
 - [postgis](https://postgis.net/) - `postgis` is the main PostGIS extension, adding support for geographic objects to the PostgreSQL database. It allows for storing and querying data based on location.
 - [postgis_raster](https://postgis.net/docs/RT_reference.html) - `postgis_raster` is an extension for handling raster data. It's used for storing and analyzing grid-based data like satellite imagery or digital elevation models.
 - [postgis_tiger_geocoder](https://postgis.net/docs/postgis_installation.html#loading_extras_tiger_geocoder) - `postgis_tiger_geocoder` provides geocoding and reverse geocoding functionality. It uses the TIGER (Topologically Integrated Geographic Encoding and Referencing) data from the US Census Bureau.
 - [postgis_topology](https://postgis.net/docs/Topology.html) - `postgis_topology` focuses on topological data models and functions, allowing for more advanced spatial data analysis and consistency.
 - [address_standardizer](https://postgis.net/docs/Extras.html#Address_Standardizer) - `address_standardizer` helps in standardizing address data, making it consistent and easier to work with, especially for geocoding purposes.
 - [address_standardizer_data_us](https://postgis.net/docs/Extras.html#Address_Standardizer) - `address_standardizer_data_us` provides the necessary data for the address_standardizer extension, specifically tailored for US addresses.
-- [fuzzystrmatch](https://www.postgresql.org/docs/current/fuzzystrmatch.html) - `fuzzystrmatch` is an additional supplied module that helps with string matching, including approximate or "fuzzy" matches. Useful in tasks like deduplication or linking different data sets where string data may not be exactly the same.
+- [mobilitydb](https://mobilitydb.com/documentation.html) - `mobilitydb` offers support for temporal and spatio-temporal objects by introducing persistent database types and query operations.
 - Extensions from [Trunk](https://pgt.dev/) can be installed on-demand.
 
 ## Getting started

--- a/docusaurus/docs/tembo-stacks/geospatial.md
+++ b/docusaurus/docs/tembo-stacks/geospatial.md
@@ -9,8 +9,9 @@ Whether dealing with spatial objects, location queries, or GIS (geographic infor
 
 ## Container Image
 
-This stack is built with a custom image, `geo-cnpg`.
-Detailed information about this image, as well as other stack images can be found in the official [tembo-images repository](https://github.com/tembo-io/tembo-images).
+This stack is built with a custom image, `geo-cnpg`, which you can find more detailed information about within the [geo-cnpg Dockerfile](https://github.com/tembo-io/tembo-images/blob/main/geo-cnpg/Dockerfile).
+
+For interest in the other Stack-specific images, please visit the official [tembo-images repository](https://github.com/tembo-io/tembo-images).
 
 ## Extensions
 

--- a/docusaurus/docs/tembo-stacks/geospatial.md
+++ b/docusaurus/docs/tembo-stacks/geospatial.md
@@ -22,7 +22,6 @@ Detailed information about this image, as well as other stack images can be foun
 - [postgis_topology](https://postgis.net/docs/Topology.html) - `postgis_topology` focuses on topological data models and functions, allowing for more advanced spatial data analysis and consistency.
 - [address_standardizer](https://postgis.net/docs/Extras.html#Address_Standardizer) - `address_standardizer` helps in standardizing address data, making it consistent and easier to work with, especially for geocoding purposes.
 - [address_standardizer_data_us](https://postgis.net/docs/Extras.html#Address_Standardizer) - `address_standardizer_data_us` provides the necessary data for the address_standardizer extension, specifically tailored for US addresses.
-- [mobilitydb](https://mobilitydb.com/documentation.html) - `mobilitydb` offers support for temporal and spatio-temporal objects by introducing persistent database types and query operations.
 - Extensions from [Trunk](https://pgt.dev/) can be installed on-demand.
 
 ## Getting started

--- a/docusaurus/docs/tembo-stacks/geospatial.md
+++ b/docusaurus/docs/tembo-stacks/geospatial.md
@@ -9,8 +9,8 @@ Whether dealing with spatial objects, location queries, or GIS (geographic infor
 
 ## Container Image
 
-This stack is built with a curated image, geo-cnpg.
-Detailed information about geo-cnpg, as well as other stack images can be found in the official [tembo-images repository](https://github.com/tembo-io/tembo-images/tree/main).
+This stack is built with a custom image, `geo-cnpg`.
+Detailed information about this image, as well as other stack images can be found in the official [tembo-images repository](https://github.com/tembo-io/tembo-images).
 
 ## Extensions
 

--- a/docusaurus/docs/tembo-stacks/geospatial.md
+++ b/docusaurus/docs/tembo-stacks/geospatial.md
@@ -7,6 +7,11 @@ sidebar_position: 9
 The Tembo Geospatial Stack is designed to bring spatial database capabilities to Postgres.
 Whether dealing with spatial objects, location queries, or GIS (geographic information systems)-facing workloads in general, this stack is pre-packaged to help.
 
+## Container Image
+
+This stack is built with a curated image, geo-cnpg.
+Detailed information about geo-cnpg, as well as other stack images can be found in the official [tembo-images repository](https://github.com/tembo-io/tembo-images/tree/main).
+
 ## Extensions
 
 - [pg_stat_statements](https://www.postgresql.org/docs/current/pgstatstatements.html) - `pg_stat_statements` is an additional supplied module that provides valuable metrics related to query performance.

--- a/docusaurus/docs/tembo-stacks/machine-learning.md
+++ b/docusaurus/docs/tembo-stacks/machine-learning.md
@@ -8,8 +8,9 @@ The Tembo Machine Learning Stack has several important Postgres extensions that 
 
 ## Container Image
 
-This stack is built with a custom image, `ml-cnpg`.
-Detailed information about this image, as well as other stack images can be found in the official [tembo-images repository](https://github.com/tembo-io/tembo-images).
+This stack is built with a custom image, `ml-cnpg`, which you can find more detailed information about within the [ml-cnpg Dockerfile](https://github.com/tembo-io/tembo-images/blob/main/ml-cnpg/Dockerfile).
+
+For interest in the other Stack-specific images, please visit the official [tembo-images repository](https://github.com/tembo-io/tembo-images).
 
 ## Extensions
 

--- a/docusaurus/docs/tembo-stacks/machine-learning.md
+++ b/docusaurus/docs/tembo-stacks/machine-learning.md
@@ -6,6 +6,11 @@ sidebar_position: 7
 
 The Tembo Machine Learning Stack has several important Postgres extensions that make it easy to train and deploy machine learning models in Postgres.
 
+## Container Image
+
+This stack is built with a custom image, `ml-cnpg`.
+Detailed information about this image, as well as other stack images can be found in the official [tembo-images repository](https://github.com/tembo-io/tembo-images).
+
 ## Extensions
 
 - [postgresml](https://pgt.dev/extensions/postgresml) - `pgml` allows you to train and run machine learning models in Postgres. It supports a variety of models and algorithms, including linear regression, logistic regression, decision tree, random forest, and k-means clustering. It also provides hooks into HuggingFace for downloading and consuming pre-trained models and transformers. Visit [PostgresML](https://github.com/postgresml/postgresml) for more details.


### PR DESCRIPTION
## Add `Container Image` section to stacks with custom images
- Add image section to highlight whether a given stack uses a custom-made image, as well as a link to the source repository, [https://github.com/tembo-io/tembo-images](https://github.com/tembo-io/tembo-images)
-- geo stack updated
-- dw stack updated
-- ml stack updated

## Update geo stack `Extensions` section
- Moved `fuzzystrmatch` to group additional supplied modules at the top of extensions section