### PR TITLE
Fix typo on machine-learning.md

### DIFF
--- a/src/content/docs/product/stacks/AI/machine-learning.md
+++ b/src/content/docs/product/stacks/AI/machine-learning.md
@@ -354,7 +354,7 @@ CREATE OR REPLACE FUNCTION predict_clickbait(
     SELECT pgml.predict(
         project_name => 'clickbait_classifier',
         features => (select vectorize.transform_embeddings(
-            input => 'warmest weather on record',
+            input => input_string,
             model_name => 'all_MiniLM_L12_v2')
         )
     )


### PR DESCRIPTION
The part [showing how to](https://tembo.io/docs/product/stacks/ai/machine-learning#serve-the-model-w-a-rest-api-using-postgrest) serve the model with PostgREST appears to copy/paste the previous embeddings example (thus doesn't use the `input_string` variable).