### PR TITLE
PLAT-549 First round of cleanup to VectorDB Stack docs

### DIFF
--- a/src/content/docs/product/stacks/AI/vectordb.md
+++ b/src/content/docs/product/stacks/AI/vectordb.md
@@ -53,7 +53,7 @@ You'll want to begin by connecting to your Postgres instance.
 psql 'postgresql://postgres:<your-password>@<your-host>:5432/postgres'
 ```
 
-### Call vectorize.table()
+### Using Hugging Face sentence transformers
 
 `vectorize.table()` works with ANY model that can be loaded via the [SentenceTransformers()](https://www.sbert.net/) API so long as it does not require any additional code execution (which includes most open source sentence transformers).
 
@@ -88,7 +88,7 @@ SELECT vectorize.table(
 );
 ```
 
-### Call vectorize.search()
+### Private models from Hugging Face
 
 If you've uploaded a [private model](https://huggingface.co/blog/introducing-private-hub) to Hugging Face, you can still host it on Tembo Cloud. Simply reference your Hugging Face org and model name,
 and pass the API key in as an `arg` to `vectorize.table()`.

--- a/src/content/docs/product/stacks/AI/vectordb.md
+++ b/src/content/docs/product/stacks/AI/vectordb.md
@@ -424,7 +424,7 @@ LIMIT 3;
  Wireless Mouse    | Pointing device without the need for a physical connection | 0.35592426991011383
 ```
 
-### How it works
+## How it works
 
 When `vectorize.table()` is executed, the extension creates jobs in [pgmq](https://github.com/tembo-io/pgmq) to generate embeddings for your existing data.
 


### PR DESCRIPTION
Reviewed for:
- Header consistency
- Grammar / phrasing / capitalization
- Formatting
- Completeness & accuracy

Further rounds of this doc should include:
- Addition of "Configuration" section clearly detailing [what's been configured and why](https://github.com/tembo-io/tembo/blob/bbb464870101a6e310477036b1dca0b1d3c3c0eb/tembo-stacks/src/stacks/specs/vectordb.yaml#L143)

Adjacent changes to the docs should include:
- Headers past H2 should **not** be displayed in right hand side navigation. _Why?_ 
           1) Level 3 and 2 headers are displayed at the same level (leads to a confusing user journey). 
           2) Headers are hidden from users as a result (i.e. the important "Support" header isn't visible unless you scroll all the way to the bottom of the content). 