### PR TITLE
Add pg-tier to extension list.

### DIFF
--- a/src/content/docs/product/software/overview.mdx
+++ b/src/content/docs/product/software/overview.mdx
@@ -18,6 +18,7 @@ import Callout from '../../../../components/Callout.astro';
 * <a href="https://github.com/tembo-io/pgmq">pgmq</a>
 * <a href="https://github.com/tembo-io/pg_vectorize">pg_vectorize</a>
 * <a href="https://github.com/tembo-io/pg_timeseries">pg_timeseries</a>
+* <a href="https://github.com/tembo-io/pg_tier">pg_tier</a>
 * <a href="https://github.com/tembo-io/pg_later">pg_later</a>
 * <a href="https://github.com/tembo-io/orb_fdw">orb_fdw</a>
 * <a href="https://github.com/tembo-io/clerk_fdw">clerk_fdw</a>


### PR DESCRIPTION
# Notes for blog or docs authors:

-   The `image: ` field in frontmatter of blogs should always be a `png` (`svg` will not work for social previews)
-   You must also duplicate the asset used in `image :` inside of the [public folder](https://github.com/tembo-io/website/tree/main/public)
-   Please write a `description: ` in the frontmatter of any new blog or doc
-   Read more [here](https://github.com/tembo-io/website?tab=readme-ov-file#writing-a-blog-post-%EF%B8%8F)
