### PR TITLE
SNI workaround doc

### DIFF
--- a/src/content/docs/getting-started/quickstarts/libpq.md
+++ b/src/content/docs/getting-started/quickstarts/libpq.md
@@ -27,6 +27,10 @@ brew reinstall libpq
 
 Please find one of the Windows installers linked from the official [Postgres documentation](https://www.postgresql.org/download/windows/).
 
+## SNI workaround
+
+If you cannot update the Postgres client, you can use [Tembo's SNI workaround](/docs/getting-started/quickstarts/sni-workaround).
+
 ## Support and Community
 
 If you encounter any issues, please check out our [troubleshooting guide](/docs/product/cloud/troubleshooting) or contact [support@tembo.io](mailto:support@tembo.io).

--- a/src/content/docs/getting-started/quickstarts/sni-workaround.md
+++ b/src/content/docs/getting-started/quickstarts/sni-workaround.md
@@ -1,5 +1,6 @@
 ---
 title: Server Name Indication (SNI)
+description: Server Name Indication connection issues workaround
 ---
 
 To connect to Tembo normally, the Postgres client must support SNI. Please see the [other guides](/docs/getting-started/quickstarts/libpq) in this section for how to pick a client that supports SNI. However if the client cannot be updated, Tembo offers a workaround solution.

--- a/src/content/docs/getting-started/quickstarts/sni-workaround.md
+++ b/src/content/docs/getting-started/quickstarts/sni-workaround.md
@@ -1,0 +1,9 @@
+---
+title: Server Name Indication (SNI)
+---
+
+To connect to Tembo normally, the Postgres client must support SNI. Please see the [other guides](/docs/getting-started/quickstarts/libpq) in this section for how to pick a client that supports SNI. However if the client cannot be updated, Tembo offers a workaround solution.
+
+Please reach out to Tembo Support ([support@tembo.io](mailto:support@tembo.io)) and specify the organization name(s) and instance name(s) for which you would like the SNI workaround applied. The workaround is manually applied by Tembo Support. An alternate domain name will be provided for your instance, which you can connect to without SNI.
+
+There is an additional cost of $20 per month for each instance where the SNI workaround is applied.

--- a/src/content/docs/product/cloud/troubleshooting.mdx
+++ b/src/content/docs/product/cloud/troubleshooting.mdx
@@ -49,6 +49,10 @@ If you want to check if you can connect to Tembo using a known, working version 
 
 If the above fails, you may be having problems reaching your cluster. Please check the previous section, or reach out to Tembo support.
 
+### SNI workaround
+
+If you cannot update the Postgres client, you can use [Tembo's SNI workaround](/docs/getting-started/quickstarts/sni-workaround).
+
 ## Certificate validation
 
 <Callout variant='info'>


### PR DESCRIPTION
# Notes for blog or docs authors:

-   The `image: ` field in frontmatter of blogs should always be a `png` (`svg` will not work for social previews)
-   You must also duplicate the asset used in `image :` inside of the [public folder](https://github.com/tembo-io/website/tree/main/public)
-   Please write a `description: ` in the frontmatter of any new blog or doc
-   Read more [here](https://github.com/tembo-io/website?tab=readme-ov-file#writing-a-blog-post-%EF%B8%8F)
