### PR TITLE
add google analytics tag

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -43,6 +43,21 @@ const {
 			})(window, document, 'script', 'dataLayer', 'GTM-5HSQFVL2');
 		</script>
 		<!-- End Google Tag Manager -->
+		<!-- Google tag (gtag.js) -->
+		<script
+			async
+			src='https://www.googletagmanager.com/gtag/js?id=G-7242E5JKJE'
+		></script>
+		<script>
+			//@ts-nocheck
+			window.dataLayer = window.dataLayer || [];
+			function gtag() {
+				dataLayer.push(arguments);
+			}
+			gtag('js', new Date());
+
+			gtag('config', 'G-7242E5JKJE');
+		</script>
 		<meta charset='UTF-8' />
 		<meta name='description' content={description} />
 		<meta name='viewport' content='width=device-width' />


### PR DESCRIPTION
# Notes for blog or docs authors:

-   The `image: ` field in frontmatter of blogs should always be a `png` (`svg` will not work for social previews)
-   You must also duplicate the asset used in `image :` inside of the [public folder](https://github.com/tembo-io/website/tree/main/public)
-   Please write a `description: ` in the frontmatter of any new blog or doc
-   Read more [here](https://github.com/tembo-io/website?tab=readme-ov-file#writing-a-blog-post-%EF%B8%8F)
