### PR TITLE
add documentation on how to increase storage via the API

### DIFF
--- a/src/content/docs/product/cloud/configuration-and-management/increase-storage.mdx
+++ b/src/content/docs/product/cloud/configuration-and-management/increase-storage.mdx
@@ -21,7 +21,7 @@ Changes will only take effect after clicking **Save**. Increasing storage does n
 
 ### Via API
 
-First, you will need to generate an API token so that you can communicate with your Tembo instance. Navigate to cloud.tembo.io/generate-jwt and follow the instructions to generate a token. Alternatively, you can follow the instructions [here](/docs/development/api).
+First, you will need to generate an API token so that you can communicate with your Tembo instance. Navigate to [cloud.tembo.io/generate-jwt](https://cloud.tembo.io/generate-jwt) and follow the instructions to generate a token. Read more about the Tembo API and tokens [here](/docs/development/api).
 
 Set your Tembo token as an environment variable, along with your organization id and the Tembo instance id. Fetch the `TEMBO_DATA_DOMAIN` from the "Host" parameter of your Tembo instance.
 

--- a/src/content/docs/product/cloud/configuration-and-management/increase-storage.mdx
+++ b/src/content/docs/product/cloud/configuration-and-management/increase-storage.mdx
@@ -1,4 +1,4 @@
----
+--
 sideBarPosition: 2
 sideBarTitle: Increasing storage
 title: Increasing storage
@@ -6,6 +6,8 @@ description: Increasing storage for your Tembo Cloud instance
 ---
 
 import Callout from '../../../../../components/Callout.astro';
+
+### Via UI
 
 Find in **Settings > Instance Settings**
 
@@ -16,3 +18,21 @@ Find in **Settings > Instance Settings**
 Changes will only take effect after clicking **Save**. Increasing storage does not restart your database.
 
 ![storage](./storage.png)
+
+### Via API
+
+First, you will need to generate an API token so that you can communicate with your Tembo instance. Navigate to cloud.tembo.io/generate-jwt and follow the instructions to generate a token. Alternatively, you can follow the instructions [here](/docs/development/api).
+
+Set your Tembo token as an environment variable, along with your organization id and the Tembo instance id. Fetch the `TEMBO_DATA_DOMAIN` from the "Host" parameter of your Tembo instance.
+
+```bash
+export TEMBO_TOKEN=<your token>
+export TEMBO_ORG=<your organization id>
+export TEMBO_INST=<your instance id>
+
+curl -X PATCH \
+	"https://api.tembo.io/api/v1/orgs/${TEMBO_ORG}/instances/${TEMBO_INST}" \
+	-H "Content-Type: application/json" \
+	-H "Authorization: Bearer ${TEMBO_TOKEN}" \
+	-d '{ "storage": "50Gi" }'
+```

--- a/src/content/docs/product/cloud/configuration-and-management/increase-storage.mdx
+++ b/src/content/docs/product/cloud/configuration-and-management/increase-storage.mdx
@@ -1,4 +1,4 @@
---
+---
 sideBarPosition: 2
 sideBarTitle: Increasing storage
 title: Increasing storage


### PR DESCRIPTION
Add documentation on how to increase storage via the API

issue: [CLOUD-645](https://linear.app/tembo/issue/CLOUD-645/after-running-out-of-storage-an-instance-cannot-recover-from)
