### PR TITLE
add planetPostgres boolean in frontmatter to power planet postgres on…

### DIFF
--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -41,6 +41,7 @@ const blog = defineCollection({
 		tags: z.array(z.string()),
 		feedSummary: z.string().optional(),
 		authors: authorsEnum,
+		planetPostgres: z.boolean().default(false)
 	}),
 });
 export const ROOT_SIDEBAR_DOCS_ORDER = {

--- a/src/pages/blog/planet-postgres-feed.xml.ts
+++ b/src/pages/blog/planet-postgres-feed.xml.ts
@@ -1,0 +1,60 @@
+import { Feed } from 'feed';
+import { getCollection } from 'astro:content';
+import { AUTHORS } from '../../blogAuthors';
+
+export async function GET() {
+	const blog = await getCollection('blog');
+	const postImportResult = import.meta.glob(
+		'../../content/blog/**/*.{md,mdx}',
+		{
+			eager: true,
+		},
+	);
+	const posts: any[] = Object.values(postImportResult).reverse();
+	const feed = new Feed({
+		title: "Tembo's Blog",
+		description:
+			'Latest news and technical blog posts from members of the Tembo team and community!',
+		id: 'https://tembo.io/blog',
+		link: 'https://tembo.io/blog',
+		language: 'en',
+		image: 'https://tembo.io/og-image.png',
+		favicon: 'http://tembo.io/favicon.ico',
+		copyright: 'All rights reserved 2024, Tembo',
+		generator: 'https://github.com/jpmonette/feed',
+		feedLinks: {
+			atom: 'https://tembo.io/atom.xml',
+			rss: 'https://tembo.io/feed.xml',
+		},
+	});
+	blog.filter((post) => post.data.planetPostgres).forEach((post) => {
+		const dateString = post.id.substring(0, 10);
+		const parsedDate = post.data?.date || new Date(dateString);
+		const COULD_NOT_BE_RENDERED = `This post contained content that could not be rendered in the Atom feed. Please use the official post link: https://tembo.io/blog/${post.slug}`;
+		const isMdx = post.id.includes('.mdx');
+		const author = AUTHORS[post.data.authors[0]];
+		const contentPost = posts.find((p) =>
+			p.frontmatter.slug.includes(post.slug),
+		);
+		feed.addItem({
+			title: post.data.title,
+			date: new Date(parsedDate),
+			description: post.data.description,
+			link: `https://tembo.io/blog/${post.slug}`,
+			content: isMdx
+				? post.data?.feedSummary || COULD_NOT_BE_RENDERED
+				: contentPost
+						?.compiledContent()
+						.replaceAll('src="/', 'src="https://tembo.io/') ||
+					COULD_NOT_BE_RENDERED,
+			author: [
+				{
+					name: author.name,
+					email: author.email,
+					link: author.url,
+				},
+			],
+		});
+	});
+	return new Response(feed.atom1());
+}


### PR DESCRIPTION
…ly atom feed

# Notes for blog or docs authors:

-   The `image: ` field in frontmatter of blogs should always be a `png` (`svg` will not work for social previews)
-   You must also duplicate the asset used in `image :` inside of the [public folder](https://github.com/tembo-io/website/tree/main/public)
-   Please write a `description: ` in the frontmatter of any new blog or doc
-   Read more [here](https://github.com/tembo-io/website?tab=readme-ov-file#writing-a-blog-post-%EF%B8%8F)
