### PR TITLE
Add revoke token doc

### DIFF
--- a/src/content/docs/development/api.md
+++ b/src/content/docs/development/api.md
@@ -7,7 +7,9 @@ To explore the Tembo Cloud API, visit our [API documentation](https://api.tembo.
 
 ### Create a personal access token
 
-After logging in to Tembo Cloud, navigate here: https://cloud.tembo.io/generate-jwt
+After logging in to Tembo Cloud, navigate here to issue a token: https://cloud.tembo.io/generate-jwt
+
+To revoke a token, please follow guidance in the documentation [here](/docs/product/cloud/security/revoke-token).
 
 ### Test an API request
 

--- a/src/content/docs/product/cloud/security/revoke-token.mdx
+++ b/src/content/docs/product/cloud/security/revoke-token.mdx
@@ -1,6 +1,7 @@
 ---
 sideBarTitle: Revoke a token
 title: Revoke a token
+description: Revoke personal access token for Tembo Cloud
 ---
 
 import Callout from '../../../../../components/Callout.astro';

--- a/src/content/docs/product/cloud/security/revoke-token.mdx
+++ b/src/content/docs/product/cloud/security/revoke-token.mdx
@@ -1,0 +1,22 @@
+---
+sideBarTitle: Revoke a token
+title: Revoke a token
+---
+
+import Callout from '../../../../../components/Callout.astro';
+
+Users can issue long-lived tokens, as described in the [API documentation](/docs/development/api).
+
+To invalidate a token, call the [API endpoint](https://api.tembo.io/swagger-ui/#/tokens/invalidate_token) for deleting tokens using that token as the authorization header.
+
+<Callout variant='info'>
+	It takes up to a minute for an invalidated token to start getting rejected by the API.
+</Callout>
+
+```bash
+export TEMBO_TOKEN="The token you want to invalidate"
+
+curl -X DELETE \
+    -H "Authorization: Bearer ${TEMBO_TOKEN}" \
+    "https://api.tembo.io/api/v1/tokens/invalidate"
+```

--- a/src/content/docs/product/cloud/security/revoke-token.mdx
+++ b/src/content/docs/product/cloud/security/revoke-token.mdx
@@ -1,7 +1,7 @@
 ---
 sideBarTitle: Revoke a token
 title: Revoke a token
-description: Revoke personal access token for Tembo Cloud
+description: Revoke a personal access token for Tembo Cloud
 ---
 
 import Callout from '../../../../../components/Callout.astro';


### PR DESCRIPTION
# Notes for blog or docs authors:

-   The `image: ` field in frontmatter of blogs should always be a `png` (`svg` will not work for social previews)
-   You must also duplicate the asset used in `image :` inside of the [public folder](https://github.com/tembo-io/website/tree/main/public)
-   Please write a `description: ` in the frontmatter of any new blog or doc
-   Read more [here](https://github.com/tembo-io/website?tab=readme-ov-file#writing-a-blog-post-%EF%B8%8F)
