### PR TITLE
tweak hero header spacing

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -54,8 +54,8 @@ const currentPath = Astro.url.pathname;
 					>
 						<header class='text-center slide-enter-content'>
 							<p
-								class='text-white font-bold tracking-[0.47px] text-[32px] sm:text-[56px] md:text-[64px] lg:text-[72px] leading-normal
-							z-10 mb-6'
+								class='text-white font-bold tracking-[0.47px] text-[32px] sm:text-[56px] md:text-[64px] lg:text-[72px] leading-tight
+							z-10 mb-12'
 							>
 								Tembo makes it easy to <br
 									class='hidden customXs:flex'


### PR DESCRIPTION
# Notes for blog or docs authors:

-   The `image: ` field in frontmatter of blogs should always be a `png` (`svg` will not work for social previews)
-   You must also duplicate the asset used in `image :` inside of the [public folder](https://github.com/tembo-io/website/tree/main/public)
-   Please write a `description: ` in the frontmatter of any new blog or doc
-   Read more [here](https://github.com/tembo-io/website?tab=readme-ov-file#writing-a-blog-post-%EF%B8%8F)
