### PR TITLE
add margin-bottom to tags in docs footer

### DIFF
--- a/src/pages/docs/[...slug].astro
+++ b/src/pages/docs/[...slug].astro
@@ -97,7 +97,7 @@ const docTitle =
 				</div>
 			</div>
 		</div>
-		<div class='flex items-start gap-2 max-h-full'>
+		<div class='flex items-start gap-2 max-h-full mb-4'>
 			{
 				doc.data.tags?.map((tag) => (
 					<Tag


### PR DESCRIPTION
# Notes for blog or docs authors:

-   The `image: ` field in frontmatter of blogs should always be a `png` (`svg` will not work for social previews)
-   You must also duplicate the asset used in `image :` inside of the [public folder](https://github.com/tembo-io/website/tree/main/public)
-   Please write a `description: ` in the frontmatter of any new blog or doc
-   Read more [here](https://github.com/tembo-io/website?tab=readme-ov-file#writing-a-blog-post-%EF%B8%8F)
