### PR TITLE
Update custom-postgres-image.mdx

### DIFF
--- a/src/content/docs/product/cloud/experimental/custom-postgres-image.mdx
+++ b/src/content/docs/product/cloud/experimental/custom-postgres-image.mdx
@@ -67,20 +67,29 @@ export TEMBO_ORG=<your organization id>
 export TEMBO_INST=<your instance id>
 ```
 
-3. Patch your existing Tembo instance with new configuration values using the [Tembo Cloud Platform API](https://api.tembo.io/redoc):
+3. Create a new instance using the [Tembo Cloud Platform API](https://api.tembo.io/redoc):
 
 ```shell
-curl -X 'PATCH' \
-  "https://api.tembo.io/api/v1/orgs/$TEMBO_ORG/instances/$TEMBO_INST" \
-  -H "accept: application/json" \
-  -H "Authorization: Bearer $TEMBO_TOKEN" \
-  -H "Content-Type: application/json" \
+curl -X 'POST' \
+  'https://api.cdb-dev.com/api/v1/orgs/org_2YW4TYIMI1LeOqJTXIyvkHOHCUo/instances' \
+  -H 'accept: application/json' \
+  -H 'Authorization: Bearer $TEMBO_TOKEN' \
+  -H 'Content-Type: application/json' \
   -d '{
+  "stack_type": "OLTP",
+  "instance_name": "my-tembo-instance",
+  "cpu": "1",
+  "memory": "2Gi",
+  "storage": "10Gi",
+  "replicas": 1,
+  "environment": "dev",
+  "spot": true,
   "experimental": {
     "image": "< your custom image here >"
   }
 }'
 ```
+
 Now, when you connect to your instance, it will have the custom dependencies available. For example:
 
 ```sql

--- a/src/content/docs/product/cloud/experimental/custom-postgres-image.mdx
+++ b/src/content/docs/product/cloud/experimental/custom-postgres-image.mdx
@@ -72,9 +72,9 @@ export TEMBO_INST=<your instance id>
 ```shell
 curl -X 'POST' \
   'https://api.tembo.io/api/v1/orgs/$TEMBO_ORG/instances/$TEMBO_INST' \
-  -H 'accept: application/json' \
-  -H 'Authorization: Bearer $TEMBO_TOKEN' \
-  -H 'Content-Type: application/json' \
+  -H "Accept: application/json" \
+  -H "Authorization: Bearer $TEMBO_TOKEN" \
+  -H "Content-Type: application/json" \
   -d '{
   "stack_type": "OLTP",
   "instance_name": "my-tembo-instance",

--- a/src/content/docs/product/cloud/experimental/custom-postgres-image.mdx
+++ b/src/content/docs/product/cloud/experimental/custom-postgres-image.mdx
@@ -71,7 +71,7 @@ export TEMBO_INST=<your instance id>
 
 ```shell
 curl -X 'POST' \
-  'https://api.cdb-dev.com/api/v1/orgs/org_2YW4TYIMI1LeOqJTXIyvkHOHCUo/instances' \
+  'https://api.tembo.io/api/v1/orgs/$TEMBO_ORG/instances/$TEMBO_INST' \
   -H 'accept: application/json' \
   -H 'Authorization: Bearer $TEMBO_TOKEN' \
   -H 'Content-Type: application/json' \

--- a/src/content/docs/product/cloud/experimental/custom-postgres-image.mdx
+++ b/src/content/docs/product/cloud/experimental/custom-postgres-image.mdx
@@ -15,6 +15,8 @@ Using a custom PostgreSQL image can allow users to install custom dependencies o
     Please reach out to Tembo support ([support@tembo.io](mailto:support@tembo.io)) if you would like to use this feature in production.
 
     Please contribute to Tembo Documentation by finding the 'Edit this page on GitHub' link at the bottom of this page.
+
+    Note: installation of extensions is only supported on creating new instances, not on existing instances.
 </Callout>
 
 ## Building an image to use with Tembo Cloud
@@ -67,7 +69,36 @@ export TEMBO_ORG=<your organization id>
 export TEMBO_INST=<your instance id>
 ```
 
-3. Create a new instance using the [Tembo Cloud Platform API](https://api.tembo.io/redoc):
+3. Patch your existing Tembo instance with new configuration values using the [Tembo Cloud Platform API](https://api.tembo.io/redoc):
+
+```shell
+curl -X 'PATCH' \
+  "https://api.tembo.io/api/v1/orgs/$TEMBO_ORG/instances/$TEMBO_INST" \
+  -H "accept: application/json" \
+  -H "Authorization: Bearer $TEMBO_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+  "experimental": {
+    "image": "< your custom image here >"
+  }
+}'
+```
+
+Now, when you connect to your instance, it will have the custom dependencies available. For example:
+
+```sql
+CREATE FUNCTION use_pandas() RETURNS void AS $$
+import pandas
+$$ LANGUAGE plpython3u;
+
+
+SELECT use_pandas();
+```
+
+## Installing Extensions with Custom images
+
+Installation of extension is only supported on creating new instances, not on existing instances.
+ To create a new instance with an extension installed in a custom image, you can use the following API call:
 
 ```shell
 curl -X 'POST' \
@@ -88,15 +119,4 @@ curl -X 'POST' \
     "image": "< your custom image here >"
   }
 }'
-```
-
-Now, when you connect to your instance, it will have the custom dependencies available. For example:
-
-```sql
-CREATE FUNCTION use_pandas() RETURNS void AS $$
-import pandas
-$$ LANGUAGE plpython3u;
-
-
-SELECT use_pandas();
 ```


### PR DESCRIPTION
PATCH does not currently work for adding new extension, but the POST (create new instance) seems like it does work for all use cases.

# Notes for blog or docs authors:

-   The `image: ` field in frontmatter of blogs should always be a `png` (`svg` will not work for social previews)
-   You must also duplicate the asset used in `image :` inside of the [public folder](https://github.com/tembo-io/website/tree/main/public)
-   Please write a `description: ` in the frontmatter of any new blog or doc
-   Read more [here](https://github.com/tembo-io/website?tab=readme-ov-file#writing-a-blog-post-%EF%B8%8F)
