### PR TITLE
Remove trunk links

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -33,12 +33,7 @@ import Status from './Status';
 						<a
 							href='https://cloud.tembo.io'
 							target='_blank'
-							rel='noreferrer'>Cloud</a
-						>
-						<a
-							href='https://pgt.dev'
-							target='_blank'
-							rel='noreferrer'>Trunk</a
+							rel='noreferrer'>Tembo Cloud</a
 						>
 						<a
 							href='https://roadmap.tembo.io/roadmap'
@@ -85,12 +80,7 @@ import Status from './Status';
 						<a
 							href='https://join.slack.com/t/tembocommunity/shared_invite/zt-277pu7chi-NHtvHWvLhHwyK0Y5Y6vTPw'
 							target='_blank'
-							rel='noreferrer'>Tembo Slack</a
-						>
-						<a
-							href='https://join.slack.com/t/trunk-community/shared_invite/zt-1yiafma92-hFHq2xAN0ukjg_2AsOVvfg'
-							target='_blank'
-							rel='noreferrer'>Trunk Slack</a
+							rel='noreferrer'>Community Slack</a
 						>
 						<a href='/contact' rel='noreferrer'>Contact us</a>
 					</div>


### PR DESCRIPTION
Since we're going to move pgt.dev content to `/extensions` I don't think we need to send our visitors off to pgt.dev or promote the trunk slack