### PR TITLE
troubleshoot wikipedia image

### DIFF
--- a/src/content/blog/2024-09-24-multimodal-image-search/index.mdx
+++ b/src/content/blog/2024-09-24-multimodal-image-search/index.mdx
@@ -217,7 +217,7 @@ Similar to conducting vector search on data with raw-text, we will use embedding
  Let's grab an image of [Cher](https://en.wikipedia.org/wiki/Cher), we can use the image from her Wikipedia page.
  Save it to `./cher_wikipedia.jpg`.
 
-<img src="https://upload.wikimedia.org/wikipedia/commons/1/1d/Cher_in_2019_cropped_1.jpg" style="width:200px;"/>
+<img src="https://upload.wikimedia.org/wikipedia/commons/1/1d/Cher_in_2019_cropped_1.jpg" alt="Cher" width="200px" />
 
 Now we can pass that single image into our `get_image_embeddings()` function and then search for similar images using `similarity_search().
 

--- a/src/content/blog/2024-09-24-multimodal-image-search/index.mdx
+++ b/src/content/blog/2024-09-24-multimodal-image-search/index.mdx
@@ -217,7 +217,7 @@ Similar to conducting vector search on data with raw-text, we will use embedding
  Let's grab an image of [Cher](https://en.wikipedia.org/wiki/Cher), we can use the image from her Wikipedia page.
  Save it to `./cher_wikipedia.jpg`.
 
-<img src="https://upload.wikimedia.org/wikipedia/commons/thumb/1/1d/Cher_in_2019_cropped_1.jpg/800px-Cher_in_2019_cropped_1.jpg" style="width:200px;"/>
+<img src="https://upload.wikimedia.org/wikipedia/commons/1/1d/Cher_in_2019_cropped_1.jpg" style="width:200px;"/>
 
 Now we can pass that single image into our `get_image_embeddings()` function and then search for similar images using `similarity_search().
 

--- a/src/content/blog/2024-09-24-multimodal-image-search/index.mdx
+++ b/src/content/blog/2024-09-24-multimodal-image-search/index.mdx
@@ -98,11 +98,9 @@ MODEL = "openai/clip-vit-base-patch32"
 image_processor = CLIPImageProcessor.from_pretrained(MODEL)
 image_model = CLIPModel.from_pretrained(MODEL)
 
-
 class ImageEmbedding(BaseModel):
     image_path: str
     embeddings: list[float]
-
 
 def get_image_embeddings(
     image_paths: list[str], normalize=True

--- a/src/content/blog/2024-09-24-multimodal-image-search/index.mdx
+++ b/src/content/blog/2024-09-24-multimodal-image-search/index.mdx
@@ -219,6 +219,7 @@ Similar to conducting vector search on data with raw-text, we will use embedding
 
 <img src="https://upload.wikimedia.org/wikipedia/commons/1/1d/Cher_in_2019_cropped_1.jpg" alt="Cher" width="200px" />
 
+
 Now we can pass that single image into our `get_image_embeddings()` function and then search for similar images using `similarity_search().
 
 ```python


### PR DESCRIPTION
# Notes for blog or docs authors:

-   The `image: ` field in frontmatter of blogs should always be a `png` (`svg` will not work for social previews)
-   You must also duplicate the asset used in `image :` inside of the [public folder](https://github.com/tembo-io/website/tree/main/public)
-   Please write a `description: ` in the frontmatter of any new blog or doc
-   Read more [here](https://github.com/tembo-io/website?tab=readme-ov-file#writing-a-blog-post-%EF%B8%8F)
