### PR TITLE
Use curly apostrophe in "Tembo’s"

### DIFF
--- a/src/components/BlogList.astro
+++ b/src/components/BlogList.astro
@@ -37,7 +37,7 @@ const resolvedPosts = await Promise.all(
 	<div class='mt-[120px] mobile:mt-[180px]'>
 		<header>
 			<h1 class='text-neon font-extrabold text-5xl lg:text-6xl z-10 mb-6'>
-				Tembo's Blog
+				Tembo’s Blog
 			</h1>
 		</header>
 		<BlogPosts posts={resolvedPosts} client:load>

--- a/src/pages/blog/atom.xml.ts
+++ b/src/pages/blog/atom.xml.ts
@@ -12,7 +12,7 @@ export async function GET() {
 	);
 	const posts: any[] = Object.values(postImportResult).reverse();
 	const feed = new Feed({
-		title: "Tembo's Blog",
+		title: "Tembo’s Blog",
 		description:
 			'Latest news and technical blog posts from members of the Tembo team and community!',
 		id: 'https://tembo.io/blog',

--- a/src/pages/blog/planet-postgres-feed.xml.ts
+++ b/src/pages/blog/planet-postgres-feed.xml.ts
@@ -12,7 +12,7 @@ export async function GET() {
 	);
 	const posts: any[] = Object.values(postImportResult).reverse();
 	const feed = new Feed({
-		title: "Tembo's Blog",
+		title: "Tembo’s Blog",
 		description:
 			'Latest news and technical blog posts from members of the Tembo team and community!',
 		id: 'https://tembo.io/blog',

--- a/src/pages/customers/arch.astro
+++ b/src/pages/customers/arch.astro
@@ -156,7 +156,7 @@ const currentPath = Astro.url.pathname;
 						of their existing skills. For internal applications,
 						Arch considered NoSQL for rapid development; however,
 						PostgreSQL offered the flexibility and power required
-						for all their use cases. Tembo's API-driven approach,
+						for all their use cases. Tembo’s API-driven approach,
 						with individual instance customization and access via
 						REST API, allows for effortless scaling without manual
 						configuration. This ensures each customer receives a
@@ -218,7 +218,7 @@ const currentPath = Astro.url.pathname;
 						variety of instance sizes they can deploy instantly,
 						which gives them predictability and flexibility, to
 						upgrade and downgrade as needed. For advanced use cases
-						and larger customers, Arch can leverage Tembo's data
+						and larger customers, Arch can leverage Tembo’s data
 						warehouse stack for optimized columnar storage without
 						needing to change their database provider or introduce
 						an “overkill” tool like Snowflake into their
@@ -251,7 +251,7 @@ const currentPath = Astro.url.pathname;
 						specialized expertise for each data platform. Arch has
 						used both Terraform and the Tembo API for fast
 						programmatic provisioning and has now built a custom API
-						client based on Tembo's open API specifications. Once
+						client based on Tembo’s open API specifications. Once
 						onboarded, each Arch customer receives a Tembo instance
 						(or set of instances) tailored to their specific needs.
 						Customers often transition their proof-of-value

--- a/src/pages/customers/schoolai.astro
+++ b/src/pages/customers/schoolai.astro
@@ -165,12 +165,12 @@ const currentPath = Astro.url.pathname;
 						service and the level and promptness of assistance
 						provided by Tembo. For instance, when they required a
 						read-only replica, Tembo delivered it within days.
-						Furthermore, another example of Tembo's exceptional
+						Furthermore, another example of Tembo’s exceptional
 						support was when the Tembo support team identified and
 						resolved a barrier SchoolAI had with Posthog. By
 						submitting a PR to Posthog's open-source repository,
 						Tembo’s team ensured that all SNI users, including
-						Tembo's, benefited from the fix.
+						Tembo’s, benefited from the fix.
 					</p>
 				</div>
 			</div>
@@ -187,7 +187,7 @@ const currentPath = Astro.url.pathname;
 						offer support without having to pick up the phone. I've
 						also seen the team proactively report outages that
 						haven't affected us. That just reassures me, all the
-						more, that Tembo's priorities align with our highest
+						more, that Tembo’s priorities align with our highest
 						priority: uptime for our production service.”
 					</div>
 					<div class='flex flex-col text-center'>

--- a/src/pages/solutions/buildcamp.astro
+++ b/src/pages/solutions/buildcamp.astro
@@ -85,7 +85,7 @@ const currentPath = Astro.url.pathname;
 					Unlock the full potential of Postgres with Tembo Buildcamp,
 					tailored to address your company's specific challenges. Our
 					buildcamp provides personalized, hands-on training to master
-					Tembo's advanced features and capabilities. From zero to use
+					Tembo’s advanced features and capabilities. From zero to use
 					case in five days, you'll be equipped to confidently put
 					Postgres to work for your company.
 				</p>

--- a/src/pages/solutions/for-enterprises.astro
+++ b/src/pages/solutions/for-enterprises.astro
@@ -72,7 +72,7 @@ const currentPath = Astro.url.pathname;
 					Postgres OSS ecosystem, providing developers confidence to use
 					Postgres however they like. It also packages and tunes Postgres
 					for common use cases, as an open-source library of
-					<a href='Thttps://tembo.io/docs/category/tembo-stacks'
+					<a href='https://tembo.io/docs/category/tembo-stacks'
 						>Tembo Stacks</a
 					>.
 				</p>


### PR DESCRIPTION
I'm assuming that Markdown is already rendered with "smartypants" mode. Probably lots more of these, but let's at least start with "Tembo’s Blog" as a page title rendering nicely, plus other instances of Tembo possessiveness.