### PR TITLE
hide overflow x on docs landing

### DIFF
--- a/src/layouts/DocsLayout.astro
+++ b/src/layouts/DocsLayout.astro
@@ -50,7 +50,7 @@ const currentPath = Astro.url.pathname;
 					logoTitle={logoTitle}
 				/>
 				<div
-					class='w-full overflow-auto scroll-pt-[120px]'
+					class='w-full overflow-auto overflow-x-hidden scroll-pt-[120px]'
 					id='docs-content'
 				>
 					<div class='flex flex-col relative'>


### PR DESCRIPTION
# Notes for blog or docs authors:

-   The `image: ` field in frontmatter of blogs should always be a `png` (`svg` will not work for social previews)
-   You must also duplicate the asset used in `image :` inside of the [public folder](https://github.com/tembo-io/website/tree/main/public)
-   Please write a `description: ` in the frontmatter of any new blog or doc
-   Read more [here](https://github.com/tembo-io/website?tab=readme-ov-file#writing-a-blog-post-%EF%B8%8F)
