### PR TITLE
fix pricing footer background color

### DIFF
--- a/src/components/JoinTemboCTA.astro
+++ b/src/components/JoinTemboCTA.astro
@@ -4,9 +4,7 @@ import { Image } from 'astro:assets';
 import ElephantStar from '@images/ElephantStar.svg';
 ---
 
-<section
-	class='tembo-for-startups-section flex w-full mb-[80px] lg:mb-[100px] px-3'
->
+<section class='tembo-for-startups-section flex w-full lg:mb-[100px] px-3'>
 	<div
 		class='flex flex-col lg:flex-row justify-between bg-white/[0.05] w-full rounded-3xl px-7 py-9 lg:px-14 gap-8 lg:gap-10'
 	>

--- a/src/pages/pricing.astro
+++ b/src/pages/pricing.astro
@@ -194,10 +194,10 @@ const supportRows = [
 			client:load
 		/>
 		<Container
-			styles='mt-[150px] customSm:mt-[150px] customMd:mt-[130px] customLg:mt-[125px] pb-[50px] md:pb-[170px] z-100'
+			styles='mt-[150px] customSm:mt-[150px] customMd:mt-[130px] customLg:mt-[125px] z-100'
 		>
 			<Faqs client:load />
-			<div class='my-[100px]'>
+			<div class='mt-[100px]'>
 				<JoinTemboCTA />
 			</div>
 		</Container>

--- a/src/pages/pricing.astro
+++ b/src/pages/pricing.astro
@@ -9,12 +9,9 @@ import rainbowArrow from '../images/rainbowArrow.svg';
 import NavBar from '../components/NavBar';
 import Layout from '../layouts/Layout.astro';
 import Container from '../components/Container';
-import Button from '../components/Button';
 import Quotes from '../components/Quotes';
 import Faqs from '../components/Faqs';
-import ArrowButton from '../components/ArrowButton.astro';
 import Footer from '../components/Footer.astro';
-import Animation from '../components/Animation';
 import FeatureCard from '../components/FeatureCard.astro';
 import BasicTable from '../components/BasicTable.astro';
 import TabbedTable from '../components/TabbedTable';
@@ -204,7 +201,7 @@ const supportRows = [
 				<JoinTemboCTA />
 			</div>
 		</Container>
-		<div class='relative'>
+		<div class='relative bg-offBlack'>
 			<div
 				class='absolute top-0 flex h-[1px] w-full flex-row items-center justify-center opacity-100 shine'
 			>


### PR DESCRIPTION
# Notes for blog or docs authors:

-   The `image: ` field in frontmatter of blogs should always be a `png` (`svg` will not work for social previews)
-   You must also duplicate the asset used in `image :` inside of the [public folder](https://github.com/tembo-io/website/tree/main/public)
-   Please write a `description: ` in the frontmatter of any new blog or doc
-   Read more [here](https://github.com/tembo-io/website?tab=readme-ov-file#writing-a-blog-post-%EF%B8%8F)
